### PR TITLE
Fix invalid video name on linux os

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -386,7 +386,7 @@ def generate(args):
             formatted_prompt = args.prompt.replace(" ", "_").replace("/",
                                                                      "_")[:50]
             suffix = '.mp4'
-            args.save_file = f"{args.task}_{args.size.replace('*','x') if sys.platform=='win32' else args.size}_{args.ulysses_size}_{formatted_prompt}_{formatted_time}" + suffix
+            args.save_file = f"{args.task}_{args.size.replace('*','x')}_{args.ulysses_size}_{formatted_prompt}_{formatted_time}" + suffix
 
         logging.info(f"Saving generated video to {args.save_file}")
         save_video(


### PR DESCRIPTION
When running inference on a Linux server and downloading videos to a local Windows PC, SFTP clients (including VSCode) fail due to invalid characters (*) in video filenames. To ensure cross-platform compatibility, we now modify filenames by removing  (*) from resolution tags for all operating systems​​, not just Windows.