### PR TITLE
Update requirements.txt for new s2v additions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ dashscope
 imageio-ffmpeg
 flash_attn
 numpy>=1.23.5,<2
+librosa
+decord


### PR DESCRIPTION
Speech to video is initialized by default even when generating in other modes (i,e I2V and T2V). Generations currently fail even after following install documentation because it currently lacks a couple packages that are introduced with S2V.