### PR TITLE
Fixes Animate Replace Bug.

### DIFF
--- a/wan/modules/animate/preprocess/video_predictor.py
+++ b/wan/modules/animate/preprocess/video_predictor.py
@@ -152,6 +152,7 @@ class SAM2VideoPredictor(_SAM2VideoPredictor):
         # metadata for each tracking frame (e.g. which direction it's tracked)
         inference_state["tracking_has_started"] = False
         inference_state["frames_already_tracked"] = {}
+        inference_state["frames_tracked_per_obj"] = {}
         # Warm up the visual backbone and cache the image feature on frame 0
         self._get_image_feature(inference_state, frame_idx=0, batch_size=1)
         return inference_state


### PR DESCRIPTION
(venv) mike@Alexandra:/project/video/Wan2.2$ python ./wan/modules/animate/preprocess/preprocess_data.py     --ckpt_path ./Wan2.2-Animate-14B/process_checkpoint/     --video_path ./source/source.mp4     --refer_path ./source/person.png     --save_path ./source/progress/     --resolution_area 1280 720     --iterations 3     --k 7     --w_len 1     --h_len 1     --replace_flag
{'ckpt_path': './Wan2.2-Animate-14B/process_checkpoint/', 'video_path': './source/source.mp4', 'refer_path': './source/person.png', 'save_path': './source/progress/', 'resolution_area': [1280, 720], 'fps': 30, 'replace_flag': True, 'retarget_flag': False, 'use_flux': False, 'iterations': 3, 'k': 7, 'w_len': 1, 'h_len': 1}
frame_num: 2646
video_fps: 30.0
fps: 30
target_num: 2646
2025-09-19 08:28:13.438 | INFO     | process_pipepline:__call__:67 - Processing pose meta
2025-09-19 08:29:23.335 | INFO     | process_pipepline:__call__:82 - Processing reference image: ./source/person.png
2025-09-19 08:29:23.352 | INFO     | process_pipepline:__call__:89 - Processing template video: ./source/source.mp4
video frame: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 400/400 [00:07<00:00, 50.11it/s]
Traceback (most recent call last):
  File "/project/video/Wan2.2/./wan/modules/animate/preprocess/preprocess_data.py", line 109, in <module>
    process_pipeline(video_path=args.video_path, 
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/video/Wan2.2/wan/modules/animate/preprocess/process_pipepline.py", line 97, in __call__
    masks = self.get_mask(frames, 400, tpl_pose_metas)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/video/Wan2.2/wan/modules/animate/preprocess/process_pipepline.py", line 319, in get_mask
    self.predictor.reset_state(inference_state)
  File "/project/video/.venv/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/project/video/.venv/lib/python3.11/site-packages/sam2/sam2_video_predictor.py", line 678, in reset_state
    self._reset_tracking_results(inference_state)
  File "/project/video/.venv/lib/python3.11/site-packages/sam2/sam2_video_predictor.py", line 701, in _reset_tracking_results
    for v in inference_state["frames_tracked_per_obj"].values():
             ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'frames_tracked_per_obj'