### PR TITLE
Add missing moviepy dependency

### DIFF
--- a/requirements_animate.txt
+++ b/requirements_animate.txt
@@ -1,3 +1,4 @@
+moviepy
 decord
 peft
 onnxruntime


### PR DESCRIPTION
The preprocess_data can't run without it:

```
/workspace/Wan2.2# python ./wan/modules/animate/preprocess/preprocess_data.py     --ckpt_path ./Wan2.2-Animate-14B/process_checkpoint     --video_path ./examples/wan_animate/replace/video.mp4     --refer_path ./examples/wan_animate/replace/image.jpeg     --save_path ./examples/wan_animate/replace/process_results     --resolution_area 1280 720     --iterations 3     --k 7     --w_len 1     --h_len 1     --replace_flag
Traceback (most recent call last):
  File "/workspace/Wan2.2/wan/modules/animate/preprocess/process_pipepline.py", line 11, in <module>
    import moviepy.editor as mpy
ModuleNotFoundError: No module named 'moviepy'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspace/Wan2.2/./wan/modules/animate/preprocess/preprocess_data.py", line 4, in <module>
    from process_pipepline import ProcessPipeline
  File "/workspace/Wan2.2/wan/modules/animate/preprocess/process_pipepline.py", line 13, in <module>
    import moviepy as mpy
ModuleNotFoundError: No module named 'moviepy'
```