### PR TITLE
Fix SAM-2 API compatibility issue in preprocessing pipeline

### DIFF
--- a/wan/modules/animate/preprocess/video_predictor.py
+++ b/wan/modules/animate/preprocess/video_predictor.py
@@ -152,6 +152,10 @@ class SAM2VideoPredictor(_SAM2VideoPredictor):
         # metadata for each tracking frame (e.g. which direction it's tracked)
         inference_state["tracking_has_started"] = False
         inference_state["frames_already_tracked"] = {}
+
+        # resolves KeyError: 'frames_tracked_per_obj' when using newer SAM-2 versions for running preprocessing in 'replacement mode'
+        inference_state["frames_tracked_per_obj"] = {}
+
         # Warm up the visual backbone and cache the image feature on frame 0
         self._get_image_feature(inference_state, frame_idx=0, batch_size=1)
         return inference_state


### PR DESCRIPTION
issue
The preprocessing pipeline for replacement mode was failing with KeyError: 'frames_tracked_per_obj'   #157 

sam-2's API expect the `frames_tracked_per_obj` dictionary in the inference state, but `video_predictor.py` wasn't initializing this required key

added initialization of `frames_tracked_per_obj` as an empty dictionary:
```python
inference_state["frames_tracked_per_obj"] = {}
```

Works fine now, see below Screenshot of output
<img width="1120" height="620" alt="Screenshot 2025-09-20 at 5 14 16 AM" src="https://github.com/user-attachments/assets/878dfa2b-bf60-49ec-a316-9feb751a7394" />

Kindly merge this asap :) 
@WanX-Video-1  @suruoxi @Steven-SWZhang  