### PR TITLE
Add missing psutil to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ easydict
 ftfy
 dashscope
 imageio-ffmpeg
+psutil
 flash_attn
 numpy>=1.23.5,<2


### PR DESCRIPTION
Add missing psutil to requirements.txt as fresh install was failing on `pip install -r requirements.txt`