### PR TITLE
Fixed an issue with unsafe dimension expansion when handling 1D timestep tensors

### DIFF
--- a/wan/modules/model.py
+++ b/wan/modules/model.py
@@ -458,6 +458,9 @@ class WanModel(ModelMixin, ConfigMixin):
 
         # time embeddings
         if t.dim() == 1:
+            # Note: expand only works for dimensions of size 1; view(-1, 1) must be called first.
+            t = t.view(-1, 1).expand(t.size(0), seq_len)
+        elif t.dim() == 2 and t.size(1) == 1:
             t = t.expand(t.size(0), seq_len)
         with torch.amp.autocast('cuda', dtype=torch.float32):
             bt = t.size(0)


### PR DESCRIPTION
Added view(-1, 1) before expanding 1D tensors:

```python
        # time embeddings
        if t.dim() == 1:
            t = t.expand(t.size(0), seq_len)
```
The original code attempted to directly expand 1D tensors to 2D, which could cause runtime errors since **expand() only works on dimensions of size 1** (or just keep the size of dimensions). The fix ensures we first reshape 1D tensors to have a size-1 dimension before expansion.
```python
        if t.dim() == 1:
            # Note: expand only works for dimensions of size 1; view(-1, 1) must be called first.
            t = t.view(-1, 1).expand(t.size(0), seq_len)
        elif t.dim() == 2 and t.size(1) == 1:
            t = t.expand(t.size(0), seq_len)
```
<img width="1543" height="747" alt="image" src="https://github.com/user-attachments/assets/2f4c3f65-6f35-4851-b550-671ad5af3ea5" />

Moreover: 
- Verified the fix handles various tensor shapes correctly
- The code correctness was validated via comprehensive i2v training experiments
