### PR TITLE
fix: replace 4 bare excepts with specific exception types

### DIFF
--- a/wan/modules/animate/preprocess/pose2d_utils.py
+++ b/wan/modules/animate/preprocess/pose2d_utils.py
@@ -24,7 +24,7 @@ def read_img(image, convert='RGB', check_exist=False):
             img = Image.open(image)
             if convert:
                 img = img.convert(convert)
-        except:
+        except (IOError, OSError):
             raise IOError('File error: ', image)
         return np.asarray(img)
     else:

--- a/wan/modules/animate/preprocess/process_pipepline.py
+++ b/wan/modules/animate/preprocess/process_pipepline.py
@@ -9,7 +9,7 @@ from loguru import logger
 from PIL import Image
 try:
     import moviepy.editor as mpy
-except:
+except ImportError:
     import moviepy as mpy
 
 from decord import VideoReader

--- a/wan/modules/animate/preprocess/utils.py
+++ b/wan/modules/animate/preprocess/utils.py
@@ -137,7 +137,7 @@ def resize_by_area(image, target_area, keep_aspect_ratio=True, divisor=64, paddi
     h, w = image.shape[:2]
     try:
         new_w, new_h = calculate_new_size(w, h, target_area, divisor)
-    except:
+    except Exception:
         aspect_ratio = w / h
 
         if keep_aspect_ratio:

--- a/wan/utils/prompt_extend.py
+++ b/wan/utils/prompt_extend.py
@@ -306,7 +306,7 @@ class QwenPromptExpander(PromptExpander):
             )
             try:
                 from .qwen_vl_utils import process_vision_info
-            except:
+            except ImportError:
                 from qwen_vl_utils import process_vision_info
             self.process_vision_info = process_vision_info
             min_pixels = 256 * 28 * 28


### PR DESCRIPTION
Replace bare `except:` with specific types across 4 files.

**Changes:**
- `pose2d_utils.py`: `except (IOError, OSError):` — image file loading
- `process_pipepline.py`: `except ImportError:` — moviepy import fallback
- `utils.py`: `except Exception:` — size calculation fallback
- `prompt_extend.py`: `except ImportError:` — qwen_vl_utils import

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt`/`SystemExit`.