### PR TITLE
Add decord to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ dashscope
 imageio-ffmpeg
 flash_attn
 numpy>=1.23.5,<2
+decord


### PR DESCRIPTION
# Description

When attempting to call this command line:
```bash
python generate.py \
--task ti2v-5B \
--size '1280*704' \
--ckpt_dir ./model/ \
--prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."
```
I received this error:
```
Traceback (most recent call last):
  File "Wan2.2/generate.py", line 17, in <module>
    import wan
  File "Wan2.2/wan/__init__.py", line 4, in <module>
    from .speech2video import WanS2V
  File "/Wan2.2/wan/speech2video.py", line 18, in <module>
    from decord import VideoReader
ModuleNotFoundError: No module named 'decord'
```

Fix that permanently by adding `decord` to `requirements.txt`.