### PR TITLE
s2v: support encoder-free inference via precomputed text embeddings

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -21,6 +21,25 @@ from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander
 from wan.utils.utils import merge_video_audio, save_video, str2bool
 
 
+def load_text_embeds(path):
+    """Load a precomputed text embedding from a .pt/.pth/.safetensors file.
+
+    Returns a tensor of shape (L, 4096) (the raw UMT5 encoder output). For
+    safetensors, the first stored tensor is used (or a tensor keyed
+    'prompt_embeds'/'embeds' if present).
+    """
+    if path is None:
+        return None
+    if path.endswith(".safetensors"):
+        from safetensors.torch import load_file
+        tensors = load_file(path)
+        for key in ("prompt_embeds", "embeds", "context"):
+            if key in tensors:
+                return tensors[key]
+        return next(iter(tensors.values()))
+    return torch.load(path, map_location="cpu")
+
+
 EXAMPLE_PROMPT = {
     "t2v-A14B": {
         "prompt":
@@ -78,6 +97,13 @@ def _validate_args(args):
 
     if args.task == "i2v-A14B":
         assert args.image is not None, "Please specify the image path for i2v."
+
+    if args.no_text_encoder or args.prompt_embeds is not None:
+        assert 's2v' in args.task, \
+            "--no_text_encoder/--prompt_embeds are only supported for s2v tasks."
+    if args.no_text_encoder:
+        assert args.prompt_embeds is not None, \
+            "--no_text_encoder requires --prompt_embeds (precomputed text embeddings)."
 
     cfg = WAN_CONFIGS[args.task]
 
@@ -294,6 +320,25 @@ def _parse_args():
         default=80,
         help="Number of frames per clip, 48 or 80 or others (must be multiple of 4) for 14B s2v"
     )
+    parser.add_argument(
+        "--no_text_encoder",
+        action="store_true",
+        default=False,
+        help="(s2v) Skip loading the UMT5 text encoder (~6 GB). Requires "
+        "--prompt_embeds to supply precomputed text embeddings.")
+    parser.add_argument(
+        "--prompt_embeds",
+        type=str,
+        default=None,
+        help="(s2v) Path to a precomputed positive-prompt text embedding "
+        "(.pt/.pth/.safetensors), shape (L, 4096). Bypasses the T5 encoder.")
+    parser.add_argument(
+        "--negative_prompt_embeds",
+        type=str,
+        default=None,
+        help="(s2v) Path to a precomputed negative-prompt text embedding "
+        "(.pt/.pth/.safetensors). Required with --prompt_embeds when "
+        "sample_guide_scale > 1.")
     args = parser.parse_args()
     _validate_args(args)
 
@@ -491,8 +536,11 @@ def generate(args):
             use_sp=(args.ulysses_size > 1),
             t5_cpu=args.t5_cpu,
             convert_model_dtype=args.convert_model_dtype,
+            load_text_encoder=not args.no_text_encoder,
         )
         logging.info(f"Generating video ...")
+        prompt_embeds = load_text_embeds(args.prompt_embeds)
+        negative_prompt_embeds = load_text_embeds(args.negative_prompt_embeds)
         video = wan_s2v.generate(
             input_prompt=args.prompt,
             ref_image_path=args.image,
@@ -512,6 +560,8 @@ def generate(args):
             seed=args.base_seed,
             offload_model=args.offload_model,
             init_first_frame=args.start_from_ref,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
         )
     else:
         logging.info("Creating WanI2V pipeline.")

--- a/precompute_text_embeds.py
+++ b/precompute_text_embeds.py
@@ -1,0 +1,111 @@
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+"""Precompute UMT5 text embeddings for the Wan2.2 S2V inferencer.
+
+Run this ONCE per fixed prompt (e.g. per anchor/variant). The resulting
+embedding file can then be fed to `generate.py --no_text_encoder
+--prompt_embeds <file>`, so the ~6 GB UMT5 text encoder never has to be
+downloaded or loaded on the GPU render pod.
+
+The saved tensor is the raw text-encoder output of shape (L, 4096); the DiT
+applies its own 4096->dim projection internally, so no further processing is
+needed at inference time.
+
+Example:
+    python precompute_text_embeds.py \
+        --task s2v-14B \
+        --ckpt_dir ./Wan2.2-S2V-14B \
+        --prompt "A news anchor reads the headlines." \
+        --output anchor_erica.pt
+"""
+import argparse
+import logging
+import os
+
+import torch
+
+from wan.configs import WAN_CONFIGS
+from wan.modules.t5 import T5EncoderModel
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Precompute UMT5 text embeddings for Wan2.2 S2V.")
+    parser.add_argument(
+        "--task",
+        type=str,
+        default="s2v-14B",
+        choices=list(WAN_CONFIGS.keys()),
+        help="Task whose text-encoder config to use.")
+    parser.add_argument(
+        "--ckpt_dir",
+        type=str,
+        required=True,
+        help="Checkpoint directory containing the UMT5 encoder + tokenizer.")
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        required=True,
+        help="Positive prompt to encode.")
+    parser.add_argument(
+        "--negative_prompt",
+        type=str,
+        default=None,
+        help="Optional negative prompt. Defaults to the task's sample "
+        "negative prompt. Use --no_negative to skip it.")
+    parser.add_argument(
+        "--no_negative",
+        action="store_true",
+        default=False,
+        help="Do not produce a negative-prompt embedding.")
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Output path for the positive embedding (.pt or .safetensors). "
+        "The negative embedding is written alongside with a '.neg' suffix.")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Device to run the encoder on.")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    cfg = WAN_CONFIGS[args.task]
+    device = torch.device(args.device)
+
+    encoder = T5EncoderModel(
+        text_len=cfg.text_len,
+        dtype=cfg.t5_dtype,
+        device=device,
+        checkpoint_path=os.path.join(args.ckpt_dir, cfg.t5_checkpoint),
+        tokenizer_path=os.path.join(args.ckpt_dir, cfg.t5_tokenizer),
+    )
+
+    def encode(text):
+        # T5EncoderModel returns a list of one (L, 4096) tensor.
+        return encoder([text], device)[0].cpu().contiguous()
+
+    def save(tensor, path):
+        if path.endswith(".safetensors"):
+            from safetensors.torch import save_file
+            save_file({"prompt_embeds": tensor}, path)
+        else:
+            torch.save(tensor, path)
+        logging.info(f"Saved {tuple(tensor.shape)} -> {path}")
+
+    pos = encode(args.prompt)
+    save(pos, args.output)
+
+    if not args.no_negative:
+        neg_prompt = args.negative_prompt
+        if neg_prompt is None:
+            neg_prompt = cfg.sample_neg_prompt
+        neg = encode(neg_prompt)
+        root, ext = os.path.splitext(args.output)
+        neg_path = f"{root}.neg{ext}"
+        save(neg, neg_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/wan/speech2video.py
+++ b/wan/speech2video.py
@@ -58,6 +58,7 @@ class WanS2V:
         t5_cpu=False,
         init_on_cpu=True,
         convert_model_dtype=False,
+        load_text_encoder=True,
     ):
         r"""
         Initializes the image-to-video generation model components.
@@ -84,6 +85,12 @@ class WanS2V:
             convert_model_dtype (`bool`, *optional*, defaults to False):
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
+            load_text_encoder (`bool`, *optional*, defaults to True):
+                Whether to load the UMT5 text encoder (~6 GB). Set to False to
+                run a precompute-only pipeline that takes text embeddings as a
+                direct input to `generate()` via `prompt_embeds`. When False,
+                `generate()` must be called with precomputed `prompt_embeds`
+                (and `negative_prompt_embeds` when `guide_scale > 1`).
         """
         self.device = torch.device(f"cuda:{device_id}")
         self.config = config
@@ -98,14 +105,22 @@ class WanS2V:
             self.init_on_cpu = False
 
         shard_fn = partial(shard_model, device_id=device_id)
-        self.text_encoder = T5EncoderModel(
-            text_len=config.text_len,
-            dtype=config.t5_dtype,
-            device=torch.device('cpu'),
-            checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
-            tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
-            shard_fn=shard_fn if t5_fsdp else None,
-        )
+        self.text_encoder = None
+        if load_text_encoder:
+            self.text_encoder = T5EncoderModel(
+                text_len=config.text_len,
+                dtype=config.t5_dtype,
+                device=torch.device('cpu'),
+                checkpoint_path=os.path.join(checkpoint_dir,
+                                             config.t5_checkpoint),
+                tokenizer_path=os.path.join(checkpoint_dir,
+                                            config.t5_tokenizer),
+                shard_fn=shard_fn if t5_fsdp else None,
+            )
+        else:
+            logging.info(
+                "Text encoder not loaded (load_text_encoder=False); "
+                "generate() expects precomputed prompt_embeds.")
 
         self.vae = Wan2_1_VAE(
             vae_pth=os.path.join(checkpoint_dir, config.vae_checkpoint),
@@ -389,6 +404,80 @@ class WanS2V:
             HEIGHT, WIDTH, target_area=max_area)
         return (HEIGHT, WIDTH)
 
+    def _to_context_list(self, embeds):
+        """Normalize precomputed text embeddings into the
+        ``list[Tensor(L, 4096)]`` format produced by the T5 encoder, placed on
+        the compute device with the model's parameter dtype.
+
+        Accepts a single ``(L, C)`` tensor, a batched ``(B, L, C)`` tensor, or a
+        list/tuple of ``(L, C)`` tensors.
+        """
+        if isinstance(embeds, torch.Tensor):
+            if embeds.dim() == 3:
+                embeds = list(embeds)
+            elif embeds.dim() == 2:
+                embeds = [embeds]
+            else:
+                raise ValueError(
+                    "text embeds tensor must be 2D (L, C) or 3D (B, L, C), "
+                    f"got shape {tuple(embeds.shape)}")
+        elif isinstance(embeds, (list, tuple)):
+            embeds = list(embeds)
+        else:
+            raise TypeError(
+                "text embeds must be a torch.Tensor or a list of tensors, "
+                f"got {type(embeds)}")
+        return [
+            e.to(device=self.device, dtype=self.param_dtype) for e in embeds
+        ]
+
+    def _prepare_text_context(self, input_prompt, n_prompt, prompt_embeds,
+                              negative_prompt_embeds, need_null, offload_model):
+        """Return ``(context, context_null)`` as lists of T5-style embeddings.
+
+        When ``prompt_embeds`` is provided the T5 encoder is bypassed entirely;
+        otherwise the prompts are encoded on the fly (requires the encoder to
+        have been loaded). ``context_null`` is ``None`` when ``need_null`` is
+        ``False`` (i.e. ``guide_scale <= 1``).
+        """
+        # Encoder-free path: caller supplied precomputed embeddings.
+        if prompt_embeds is not None:
+            context = self._to_context_list(prompt_embeds)
+            if need_null:
+                if negative_prompt_embeds is None:
+                    raise ValueError(
+                        "guide_scale > 1 requires negative_prompt_embeds when "
+                        "prompt_embeds is supplied (no text encoder to fall "
+                        "back on).")
+                context_null = self._to_context_list(negative_prompt_embeds)
+            else:
+                context_null = None
+            return context, context_null
+
+        # Fallback path: encode with the T5 encoder.
+        if self.text_encoder is None:
+            raise RuntimeError(
+                "No text encoder loaded (load_text_encoder=False) and no "
+                "prompt_embeds provided. Pass precomputed prompt_embeds (and "
+                "negative_prompt_embeds when guide_scale > 1).")
+        if not self.t5_cpu:
+            self.text_encoder.model.to(self.device)
+            context = self.text_encoder([input_prompt], self.device)
+            context_null = self.text_encoder([n_prompt],
+                                             self.device) if need_null else None
+            if offload_model:
+                self.text_encoder.model.cpu()
+        else:
+            context = self.text_encoder([input_prompt], torch.device('cpu'))
+            context = [t.to(self.device) for t in context]
+            if need_null:
+                context_null = self.text_encoder([n_prompt],
+                                                 torch.device('cpu'))
+                context_null = [t.to(self.device) for t in context_null]
+            else:
+                context_null = None
+        return context, context_null
+
     def generate(
         self,
         input_prompt,
@@ -410,6 +499,8 @@ class WanS2V:
         seed=-1,
         offload_model=True,
         init_first_frame=False,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
     ):
         r"""
         Generates video frames from input image and text prompt using diffusion process.
@@ -448,6 +539,16 @@ class WanS2V:
                 If True, offloads models to CPU during generation to save VRAM
             init_first_frame (`bool`, *optional*, defaults to False):
                 Whether to use the reference image as the first frame (i.e., standard image-to-video generation)
+            prompt_embeds (`torch.Tensor` or `list[torch.Tensor]`, *optional*):
+                Precomputed UMT5 text embeddings for the positive prompt, of
+                shape `(L, 4096)` (or `(1, L, 4096)` / a single-element list).
+                These are the raw text-encoder outputs (pre-projection); the
+                DiT applies its own 4096->dim projection internally. When given,
+                the T5 encoder is bypassed entirely (and need not be loaded).
+            negative_prompt_embeds (`torch.Tensor` or `list[torch.Tensor]`, *optional*):
+                Precomputed UMT5 text embeddings for the negative prompt, same
+                format as `prompt_embeds`. Required when `guide_scale > 1` and
+                `prompt_embeds` is supplied.
 
         Returns:
             torch.Tensor:
@@ -518,18 +619,15 @@ class WanS2V:
         if n_prompt == "":
             n_prompt = self.sample_neg_prompt
 
-        # preprocess
-        if not self.t5_cpu:
-            self.text_encoder.model.to(self.device)
-            context = self.text_encoder([input_prompt], self.device)
-            context_null = self.text_encoder([n_prompt], self.device)
-            if offload_model:
-                self.text_encoder.model.cpu()
-        else:
-            context = self.text_encoder([input_prompt], torch.device('cpu'))
-            context_null = self.text_encoder([n_prompt], torch.device('cpu'))
-            context = [t.to(self.device) for t in context]
-            context_null = [t.to(self.device) for t in context_null]
+        # text conditioning: prefer precomputed embeddings (encoder-free path),
+        # otherwise fall back to encoding with the (optional) T5 encoder.
+        context, context_null = self._prepare_text_context(
+            input_prompt=input_prompt,
+            n_prompt=n_prompt,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            need_null=guide_scale > 1,
+            offload_model=offload_model)
 
         out = []
         # evaluation mode


### PR DESCRIPTION
Drop the requirement to load the ~6.27 GB UMT5 text encoder on the render path. WanS2V can now bypass T5 entirely and take precomputed text embeddings as a direct input, saving the encoder download on cold GPU pods (~28% of the fp8 weight set / ~17% of bf16) for the common case where the prompt is fixed and only the audio changes.

- WanS2V.__init__(load_text_encoder=True): skip loading T5 when False
- WanS2V.generate(prompt_embeds, negative_prompt_embeds): bypass T5 when given; new _prepare_text_context / _to_context_list helpers. Embeds are the raw UMT5 output (L, 4096); the DiT keeps its internal projection.
- generate.py: --no_text_encoder / --prompt_embeds / --negative_prompt_embeds CLI flags + load_text_embeds() loader + fail-fast validation
- precompute_text_embeds.py: helper to produce embedding files offline

Backward compatible: without the new flags behavior is unchanged.